### PR TITLE
Add dynamic in-stock filter to pedals filter bar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,13 @@ export const metadata: Metadata = {
   description: 'Handcrafted guitar effects pedals'
 };
 
+/**
+ * Renders the application's root HTML layout including language, font variables, header, and page content.
+ *
+ * @param children - The page content to render inside the layout's body.
+ * @returns The top-level HTML element (html > body) containing the Header and the provided `children`.
+ */
+
 export default function RootLayout({
   children
 }: Readonly<{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,12 @@ import { PedalFilterId } from '@/modules/pedals/types';
 import PedalFiltersBar from '@/modules/pedals/ui/pedals-filter-bar';
 import { useMemo, useState } from 'react';
 
-// TODO: Doc strings
+/**
+ * Renders the pedals home page with a filter bar and a responsive grid of pedal items.
+ *
+ * @returns The page React element containing the filter controls and the pedal results grid.
+ */
+
 export default function Home() {
   const [selectedFilter, setSelectedFilter] = useState<PedalFilterId>('all');
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import { useMemo, useState } from 'react';
  */
 
 export default function Home() {
-  const [selectedFilter, setSelectedFilter] = useState<PedalFilterId>('all');
+  const [selectedFilter, setSelectedFilter] = useState<PedalFilterId>('All');
 
   const pedals = useMemo(
     () => getPedalsForFilter(selectedFilter),

--- a/src/app/pedals/[pedalName]/page.tsx
+++ b/src/app/pedals/[pedalName]/page.tsx
@@ -1,4 +1,9 @@
-import { ProductCard } from '@/components/ui/brown-bear-components/product-card';
+/**
+ * Render a product page component that displays the pedal name in a header.
+ *
+ * @param params - A promise that resolves to an object with `pedalName`, which is used as the displayed product name.
+ * @returns A JSX element containing an `h1` with the text "product page {pedalName}".
+ */
 
 export default async function Page({
   params

--- a/src/app/pedals/page.tsx
+++ b/src/app/pedals/page.tsx
@@ -3,7 +3,7 @@ import { getAvailablePedals } from '@/modules/pedals/queries';
 
 export default function PedalsPage() {
   const pedals = getAvailablePedals();
-  console.log(`available: ${JSON.stringify(pedals, null, 2)}`);
+  git;
   return (
     <main className="mx-auto max-w-6xl px-4 py-10">
       {/* Optional heading / filters go here */}

--- a/src/app/pedals/page.tsx
+++ b/src/app/pedals/page.tsx
@@ -3,7 +3,6 @@ import { getAvailablePedals } from '@/modules/pedals/queries';
 
 export default function PedalsPage() {
   const pedals = getAvailablePedals();
-  git;
   return (
     <main className="mx-auto max-w-6xl px-4 py-10">
       {/* Optional heading / filters go here */}

--- a/src/app/pedals/page.tsx
+++ b/src/app/pedals/page.tsx
@@ -3,6 +3,7 @@ import { getAvailablePedals } from '@/modules/pedals/queries';
 
 export default function PedalsPage() {
   const pedals = getAvailablePedals();
+  console.log(`available: ${JSON.stringify(pedals, null, 2)}`);
   return (
     <main className="mx-auto max-w-6xl px-4 py-10">
       {/* Optional heading / filters go here */}

--- a/src/components/ui/brown-bear-components/header.tsx
+++ b/src/components/ui/brown-bear-components/header.tsx
@@ -7,6 +7,14 @@ import type { KeyboardEvent } from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Render the site header with brand, desktop navigation (accessible dropdowns for Pedals and Contact), and a mobile navigation panel.
+ *
+ * The header includes active-link highlighting, keyboard-accessible dropdown menus with focus management, and a toggleable mobile menu with a focus trap.
+ *
+ * @returns The header JSX element containing site navigation, dropdown menus, and the mobile navigation panel.
+ */
+
 export default function Header() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);

--- a/src/components/ui/brown-bear-components/pedal-grid-item.tsx
+++ b/src/components/ui/brown-bear-components/pedal-grid-item.tsx
@@ -15,6 +15,13 @@ interface PedalGridItemProps {
   className?: string;
 }
 
+/**
+ * Render a clickable product tile for a pedal showing its image, title, and either the price or a "Sold out" label.
+ *
+ * @param props - Component props including `slug`, `name`, `priceCents`, `imageUrl`, `status`, and optional `className`.
+ * @returns The React element for the pedal grid item.
+ */
+
 export function PedalGridItem(props: PedalGridItemProps) {
   const { slug, name, priceCents, imageUrl, status, className } = props;
   const isSold = status === 'sold';

--- a/src/components/ui/brown-bear-components/product-list.tsx
+++ b/src/components/ui/brown-bear-components/product-list.tsx
@@ -11,7 +11,13 @@ interface ProductCardProps {
   tags?: string[];
 }
 
-// TODO: Doc strings
+/**
+ * Render a PedalGridItem for a product using the provided product props.
+ *
+ * @param status - Product availability status; when `undefined`, defaults to `'available'`.
+ * @returns A JSX element rendering a configured `PedalGridItem`.
+ */
+
 export default function ProductList({
   slug,
   name,

--- a/src/modules/pedals/queries.ts
+++ b/src/modules/pedals/queries.ts
@@ -74,10 +74,11 @@ export function getAvailablePedalsByType(type: PedalType): Pedal[] {
  */
 
 export function getPedalsForFilter(filter: PedalFilterId): Pedal[] {
-  if (filter === 'All') {
-    return getAvailablePedals();
-  }
-  return getAvailablePedals().filter((pedal) => pedal.type === filter);
+  const available = getAvailablePedals();
+
+  return filter === 'All'
+    ? available
+    : available.filter((pedal) => pedal.type === filter);
 }
 
 /**

--- a/src/modules/pedals/queries.ts
+++ b/src/modules/pedals/queries.ts
@@ -74,7 +74,7 @@ export function getAvailablePedalsByType(type: PedalType): Pedal[] {
  */
 
 export function getPedalsForFilter(filter: PedalFilterId): Pedal[] {
-  if (filter === 'all') {
+  if (filter === 'All') {
     return getAvailablePedals();
   }
   return getAvailablePedals().filter((pedal) => pedal.type === filter);

--- a/src/modules/pedals/queries.ts
+++ b/src/modules/pedals/queries.ts
@@ -69,7 +69,7 @@ export function getAvailablePedalsByType(type: PedalType): Pedal[] {
 /**
  * Returns available pedals matching the provided filter.
  *
- * @param filter - `'all'` to return all available pedals, otherwise a pedal type used to filter available pedals.
+ * @param filter - `'All'` to return all available pedals, otherwise a pedal type used to filter available pedals.
  * @returns An array of available pedals that match the filter.
  */
 

--- a/src/modules/pedals/queries.ts
+++ b/src/modules/pedals/queries.ts
@@ -57,12 +57,22 @@ export function getPedalsByType(type: PedalType): Pedal[] {
 /**
  * Filter by available pedals and type
  * (e.g. "Overdrive", "Fuzz", etc.)
+ * Get available pedals matching the given pedal type.
+ *
+ * @param type - The pedal type to filter by (e.g., "Overdrive", "Fuzz")
+ * @returns An array of pedals whose status is `'available'` and whose `type` equals `type`
  */
 export function getAvailablePedalsByType(type: PedalType): Pedal[] {
   return getAvailablePedals().filter((pedal) => pedal.type === type);
 }
 
-// TODO: Doc strings
+/**
+ * Returns available pedals matching the provided filter.
+ *
+ * @param filter - `'all'` to return all available pedals, otherwise a pedal type used to filter available pedals.
+ * @returns An array of available pedals that match the filter.
+ */
+
 export function getPedalsForFilter(filter: PedalFilterId): Pedal[] {
   if (filter === 'all') {
     return getAvailablePedals();
@@ -73,6 +83,10 @@ export function getPedalsForFilter(filter: PedalFilterId): Pedal[] {
 /**
  * Find all pedals in a line
  * (e.g. "Tarot", "Limited", "Custom" etc.)
+ * Get pedals belonging to the specified product line.
+ *
+ * @param productLine - The product line to filter by (e.g., "Tarot", "Limited", "Custom").
+ * @returns An array of pedals whose `productLine` strictly equals the provided product line.
  */
 export function getPedalsByProductLine(productLine: ProductLine): Pedal[] {
   return pedals.filter((pedal) => pedal.productLine === productLine);

--- a/src/modules/pedals/types.ts
+++ b/src/modules/pedals/types.ts
@@ -20,7 +20,7 @@ export type PedalType =
   | 'Buffers'
   | 'Amp Sim';
 
-export type PedalFilterId = 'all' | PedalType;
+export type PedalFilterId = 'All' | PedalType;
 
 export interface Pedal {
   slug: string;

--- a/src/modules/pedals/types.ts
+++ b/src/modules/pedals/types.ts
@@ -1,4 +1,3 @@
-// TODO: Doc strings
 export type ProductStatus = 'available' | 'sold' | 'coming_soon';
 
 export type ProductLine =

--- a/src/modules/pedals/ui/pedals-filter-bar.tsx
+++ b/src/modules/pedals/ui/pedals-filter-bar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { PedalFilterId } from '../types';
+import { Pedal, PedalFilterId } from '../types';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { getAvailablePedals } from '../queries';
 
 interface PedalFiltersBarProps {
   selectedFilter: PedalFilterId;
@@ -11,7 +12,7 @@ interface PedalFiltersBarProps {
 
 type FilterOption = { id: PedalFilterId; label: string };
 const filterOptions: FilterOption[] = [
-  { id: 'all', label: 'All Products' },
+  { id: 'All', label: 'All Products' },
   { id: 'Overdrive', label: 'Overdrive' },
   { id: 'Distortion', label: 'Distortion' },
   { id: 'Fuzz', label: 'Fuzz' },
@@ -24,6 +25,12 @@ const filterOptions: FilterOption[] = [
   { id: 'Amp Sim', label: 'Amp Sim' }
 ];
 
+const currentStock: Pedal[] = getAvailablePedals();
+const uniqueTypes = Array.from(
+  new Set(currentStock.map((pedal) => pedal.type))
+);
+const filterIds: PedalFilterId[] = ['All', ...uniqueTypes];
+console.log(`uniqueTypes: ${uniqueTypes}`);
 /**
  * Renders a horizontal, responsive bar of filter buttons for pedal categories.
  *
@@ -37,22 +44,22 @@ export default function PedalFiltersBar(props: PedalFiltersBarProps) {
 
   return (
     <div className="flex flex-wrap gap-3">
-      {filterOptions.map((filter) => {
-        const isActive = filter.id === selectedFilter;
+      {filterIds.map((filter) => {
+        const isActive = filter === selectedFilter;
 
         return (
           <Button
-            key={filter.id}
+            key={filter}
             aria-pressed={isActive}
             size="lg"
             variant="link"
-            onClick={() => onFilterChange(filter.id)}
+            onClick={() => onFilterChange(filter)}
             className={cn(
               'bg-white transition-all duration-300 hover:scale-[1.18] text-muted-foreground hover:text-black',
               isActive && 'text-black underline scale-[1.18]'
             )}
           >
-            {filter.label}
+            {filter}
           </Button>
         );
       })}

--- a/src/modules/pedals/ui/pedals-filter-bar.tsx
+++ b/src/modules/pedals/ui/pedals-filter-bar.tsx
@@ -11,11 +11,11 @@ interface PedalFiltersBarProps {
 }
 
 const currentStock: Pedal[] = getAvailablePedals();
+// Get unique types
 const uniqueTypes = Array.from(
   new Set(currentStock.map((pedal) => pedal.type))
 );
 const filterIds: PedalFilterId[] = ['All', ...uniqueTypes];
-console.log(`uniqueTypes: ${uniqueTypes}`);
 /**
  * Renders a horizontal, responsive bar of filter buttons for pedal categories.
  *

--- a/src/modules/pedals/ui/pedals-filter-bar.tsx
+++ b/src/modules/pedals/ui/pedals-filter-bar.tsx
@@ -24,6 +24,14 @@ const filterOptions: FilterOption[] = [
   { id: 'Amp Sim', label: 'Amp Sim' }
 ];
 
+/**
+ * Renders a horizontal, responsive bar of filter buttons for pedal categories.
+ *
+ * @param props.selectedFilter - Currently active filter id; the corresponding button is styled and exposed via `aria-pressed`.
+ * @param props.onFilterChange - Callback invoked with the selected filter id when a button is clicked.
+ * @returns A React element containing the row of filter buttons.
+ */
+
 export default function PedalFiltersBar(props: PedalFiltersBarProps) {
   const { selectedFilter, onFilterChange } = props;
 

--- a/src/modules/pedals/ui/pedals-filter-bar.tsx
+++ b/src/modules/pedals/ui/pedals-filter-bar.tsx
@@ -10,21 +10,6 @@ interface PedalFiltersBarProps {
   onFilterChange: (nextFilter: PedalFilterId) => void;
 }
 
-type FilterOption = { id: PedalFilterId; label: string };
-const filterOptions: FilterOption[] = [
-  { id: 'All', label: 'All Products' },
-  { id: 'Overdrive', label: 'Overdrive' },
-  { id: 'Distortion', label: 'Distortion' },
-  { id: 'Fuzz', label: 'Fuzz' },
-  { id: 'Delay', label: 'Delay' },
-  { id: 'Modulation', label: 'Modulation' },
-  { id: 'Boost', label: 'Boost' },
-  { id: 'Preamp', label: 'Preamp' },
-  { id: 'Utility', label: 'Utility' },
-  { id: 'Buffers', label: 'Buffers' },
-  { id: 'Amp Sim', label: 'Amp Sim' }
-];
-
 const currentStock: Pedal[] = getAvailablePedals();
 const uniqueTypes = Array.from(
   new Set(currentStock.map((pedal) => pedal.type))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Filter bar now builds its options from current inventory so only available pedal types are shown.
  * Initial filter selection normalized to "All", ensuring the homepage starts by showing all available pedals.
  * Product lists continue to default to available items; product pages and header behavior unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->